### PR TITLE
Add Supabase-powered post feed

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -54,6 +54,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="add"
+        options={{
+          title: 'Add',
+          tabBarIcon: ({ color }) => <TabBarIcon name="plus" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/add.tsx
+++ b/app/(tabs)/add.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { router } from 'expo-router';
+
+import { supabase } from '@/lib/supabase';
+
+export default function AddPostScreen() {
+  const [user, setUser] = useState('');
+  const [image, setImage] = useState('');
+  const [caption, setCaption] = useState('');
+  const [bio, setBio] = useState('');
+  const [url, setUrl] = useState('');
+
+  const submit = async () => {
+    if (!user || !image) return;
+    await supabase.from('posts').insert({ user, image, caption, bio, url });
+    setUser('');
+    setImage('');
+    setCaption('');
+    setBio('');
+    setUrl('');
+    router.push('/(tabs)/index');
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput placeholder="User" value={user} onChangeText={setUser} style={styles.input} />
+      <TextInput placeholder="Image URL" value={image} onChangeText={setImage} style={styles.input} />
+      <TextInput placeholder="Caption" value={caption} onChangeText={setCaption} style={styles.input} />
+      <TextInput placeholder="Bio" value={bio} onChangeText={setBio} style={styles.input} />
+      <TextInput placeholder="URL" value={url} onChangeText={setUrl} style={styles.input} />
+      <Button title="Post" onPress={submit} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,7 @@
 import { Image, FlatList, StyleSheet } from 'react-native';
+import { useEffect, useState } from 'react';
+
+import { supabase } from '@/lib/supabase';
 
 import { Text, View } from '@/components/Themed';
 
@@ -7,55 +10,39 @@ type Post = {
   user: string;
   image: string;
   caption: string;
+  bio: string;
+  url: string;
 };
 
-const POSTS: Post[] = [
-  {
-    id: '1',
-    user: 'Jane Doe',
-    image: 'https://picsum.photos/id/1018/800/600',
-    caption: 'Enjoying the sunshine!',
-  },
-  {
-    id: '2',
-    user: 'John Smith',
-    image: 'https://picsum.photos/id/1025/800/600',
-    caption: 'Adventure time!',
-  },
-  {
-    id: '3',
-    user: 'Alice',
-    image: 'https://picsum.photos/id/1035/800/600',
-    caption: 'A beautiful view.',
-  },
-  {
-    id: '4',
-    user: 'Bob',
-    image: 'https://picsum.photos/id/1043/800/600',
-    caption: 'Lunchtime vibes.',
-  },
-  {
-    id: '5',
-    user: 'Charlie',
-    image: 'https://picsum.photos/id/1062/800/600',
-    caption: 'Exploring the city.',
-  },
-];
-
 export default function TabOneScreen() {
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    const loadPosts = async () => {
+      const { data, error } = await supabase.from('posts').select('*');
+      if (!error && data) {
+        setPosts(data as Post[]);
+      }
+    };
+
+    loadPosts();
+  }, []);
+
   const renderItem = ({ item }: { item: Post }) => (
     <View style={styles.post}>
       <Text style={styles.user}>{item.user}</Text>
       <Image source={{ uri: item.image }} style={styles.image} />
       <Text style={styles.caption}>{item.caption}</Text>
+      <Text style={styles.bio}>{item.bio}</Text>
+      <Text style={styles.url}>{item.url}</Text>
     </View>
   );
 
   return (
     <View style={styles.container}>
       <FlatList
-        data={POSTS}
-        keyExtractor={(item) => item.id}
+        data={posts}
+        keyExtractor={(item) => String(item.id)}
         renderItem={renderItem}
         showsVerticalScrollIndicator={false}
       />
@@ -82,5 +69,15 @@ const styles = StyleSheet.create({
   caption: {
     margin: 8,
     fontSize: 14,
+  },
+  bio: {
+    marginHorizontal: 8,
+    fontSize: 12,
+    color: '#666',
+  },
+  url: {
+    marginHorizontal: 8,
+    fontSize: 12,
+    color: '#1e90ff',
   },
 });

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = 'https://tpjyejgrnwssnbnuxsfq.supabase.co';
+const supabaseKey = process.env.SUPABASE_KEY ?? '';
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-navigation/native": "^7.1.6",
+        "@supabase/supabase-js": "^2.50.0",
         "expo": "~53.0.11",
         "expo-font": "~13.3.1",
         "expo-linking": "~7.1.5",
@@ -3097,6 +3098,102 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.70.0.tgz",
+      "integrity": "sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.10",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.10.tgz",
+      "integrity": "sha512-SJKVa7EejnuyfImrbzx+HaD9i6T784khuw1zP+MBD7BmJYChegGxYigPzkKX8CK8nGuDntmeSD3fvriaH0EGZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.50.0.tgz",
+      "integrity": "sha512-M1Gd5tPaaghYZ9OjeO1iORRqbTWFEz/cF3pPubRnMPzA+A8SiUsXXWDP+DWsASZcjEcVEcVQIAF38i5wrijYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.70.0",
+        "@supabase/functions-js": "2.4.4",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.10",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -3240,6 +3337,12 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
@@ -3262,6 +3365,15 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
     "@react-navigation/native": "^7.1.6",
+    "@supabase/supabase-js": "^2.50.0",
     "expo": "~53.0.11",
     "expo-font": "~13.3.1",
     "expo-linking": "~7.1.5",


### PR DESCRIPTION
## Summary
- add Supabase client helper
- fetch posts from Supabase on Tab One
- show bio and url in each post
- add a new tab with a plus icon to create posts
- add Supabase dependency

## Testing
- `npx jest` *(fails: Cannot find module '../Libraries/Components/AccessibilityInfo/AccessibilityInfo')*

------
https://chatgpt.com/codex/tasks/task_e_684836296af0832ebc1ff722470686e4