### PR TITLE
Fix supabase key env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Social App
+
+This Expo application uses Supabase for data storage.
+
+## Environment variables
+
+Expo only bundles variables prefixed with `EXPO_PUBLIC_`. Ensure that your Supabase key is provided via `EXPO_PUBLIC_SUPABASE_KEY` (e.g. in `.env` or your shell environment) so it is accessible at runtime.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = 'https://tpjyejgrnwssnbnuxsfq.supabase.co';
-const EXPO_PUBLIC_SUPABASE_KEY = process.env.SUPABASE_KEY ?? '';
+// Expo only exposes environment variables prefixed with `EXPO_PUBLIC_` at runtime
+// so we read the key from `EXPO_PUBLIC_SUPABASE_KEY`.
+const supabaseKey = process.env.EXPO_PUBLIC_SUPABASE_KEY ?? '';
 
-export const supabase = createClient(supabaseUrl, EXPO_PUBLIC_SUPABASE_KEY);
+export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- fix env var name in `supabase` client
- document required env var

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e8c2b2bc832ea87ec564ddcd268c