### PR TITLE
Improve TabOne feed layout

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
-import { Image, FlatList, StyleSheet } from 'react-native';
+import { Image, FlatList, StyleSheet, Pressable } from 'react-native';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { useEffect, useState } from 'react';
 
 import { supabase } from '@/lib/supabase';
@@ -32,9 +33,12 @@ export default function TabOneScreen() {
     <View style={styles.post}>
       <Text style={styles.user}>{item.user}</Text>
       <Image source={{ uri: item.image }} style={styles.image} />
+      <View style={styles.actions}>
+        <Pressable>
+          <FontAwesome name="heart-o" size={24} color="#ff3333" />
+        </Pressable>
+      </View>
       <Text style={styles.caption}>{item.caption}</Text>
-      <Text style={styles.bio}>{item.bio}</Text>
-      <Text style={styles.url}>{item.url}</Text>
     </View>
   );
 
@@ -70,14 +74,9 @@ const styles = StyleSheet.create({
     margin: 8,
     fontSize: 14,
   },
-  bio: {
-    marginHorizontal: 8,
-    fontSize: 12,
-    color: '#666',
-  },
-  url: {
-    marginHorizontal: 8,
-    fontSize: 12,
-    color: '#1e90ff',
+  actions: {
+    flexDirection: 'row',
+    paddingHorizontal: 8,
+    paddingVertical: 12,
   },
 });

--- a/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `null`;


### PR DESCRIPTION
## Summary
- show posts with images and captions like a social feed
- add a placeholder like button
- update test snapshot

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ee93ce18832eb7ad7df20396d7a4